### PR TITLE
feat: docker deployment frontend & backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,54 @@
+# Basis-Image
+FROM node:18-alpine AS base
+
+# Install system dependencies
+RUN apk add --no-cache libc6-compat libreoffice ttf-liberation
+
+WORKDIR /app
+
+# Dependencies installieren
+FROM base AS deps
+COPY package.json package-lock.json* yarn.lock* pnpm-lock.yaml* ./
+
+RUN \
+  if [ -f yarn.lock ]; then yarn install --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm install --frozen-lockfile; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
+
+# Build stage
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . /app
+
+RUN \
+  if [ -f yarn.lock ]; then yarn run build; \
+  elif [ -f package-lock.json ]; then npm run build; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
+
+# Production image
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 fastify
+
+# Copy built application
+COPY --from=builder --chown=fastify:nodejs /app/dist ./dist
+COPY --from=deps --chown=fastify:nodejs /app/node_modules ./node_modules
+COPY --from=builder --chown=fastify:nodejs /app/package.json ./package.json
+
+USER fastify
+
+EXPOSE 4000
+
+ENV PORT=4000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "dist/server.js"]

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES6",
     "module": "CommonJS",
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "strict": true,
     "allowSyntheticDefaultImports": true
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,13 +1,32 @@
 services:
-  app:
+  frontend:
     build:
-      context: .
+      context: ./frontend
       dockerfile: Dockerfile
-    container_name: werkzeugkiste
+    container_name: werkzeugkiste-frontend
     environment:
-      NODE_ENV: production
-      HOSTNAME: 0.0.0.0
-      PORT: 3000
+      - NODE_ENV=production
+      - HOSTNAME=0.0.0.0
+      - PORT=3000
+      - backend_url=http://backend:4000
     ports:
       - "3000:3000"
     restart: unless-stopped
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: werkzeugkiste-backend
+    environment:
+      - NODE_ENV=production
+      - HOSTNAME=0.0.0.0
+      - PORT=4000
+      - CORS_ORIGIN=http://frontend:3000
+    ports:
+      - "4000:4000"
+    restart: unless-stopped
+
+networks:
+  default:
+    driver: bridge

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,11 +5,11 @@ FROM node:18-alpine AS base
 # Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat libreoffice ttf-liberation
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY frontend/package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
@@ -47,13 +47,18 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
 EXPOSE 3000
-ENV PORT=3000
-ENV HOSTNAME="0.0.0.0"
 
+ENV PORT=3000
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
+ENV HOSTNAME="0.0.0.0"
 CMD ["node", "server.js"]


### PR DESCRIPTION
There are two Dockerfiles now for each the frontend and backend in conjunction with a docker compose for building both contexts and deploying the stack. 

The NextJS Dockerfile in the frontend folder is just the example from Vercel's Github (https://github.com/vercel/next.js/tree/canary/examples/with-docker). 

Because the Fastify backend is based on NodeJS just like the frontend, a similar structure was used in the Dockerfile with slight changes regarding the configuration.

Ultimately, the Docker Compose file creates a build in both contexts with minimal configuration of e.g. ports and URLs using environment variables.